### PR TITLE
Fix number format issue in MIM provider

### DIFF
--- a/src/Provider/Mim.php
+++ b/src/Provider/Mim.php
@@ -56,9 +56,9 @@ class Mim extends AbstractProvider
         if (mb_substr($mobile, 0, 2) == '01') {
             $number = $mobile;
         } elseif (mb_substr($mobile, 0, 2) == '88') {
-            $number = str_replace('88', '', $mobile);
+            $number = mb_substr($mobile, 2);
         } elseif (mb_substr($mobile, 0, 3) == '+88') {
-            $number = str_replace('+88', '', $mobile);
+            $number = mb_substr($mobile, 3);
         }
         return '88' . $number;
     }


### PR DESCRIPTION
## The Problem

Package tries to send to invalid number when user providers destination number starting with '88' and containing '88' somewhere in the number. 

**Example**:

```php
formatNumber('8801742433788') // 88017424337
formatNumber('8801884328812') // 880143212
```

## After Fix

```php
formatNumber('8801742433788') // 8801742433788
formatNumber('8801884328812') // 8801884328812
```